### PR TITLE
C64 core loadable SID filter

### DIFF
--- a/firmware/misterynano_fw/menu.c
+++ b/firmware/misterynano_fw/menu.c
@@ -135,7 +135,6 @@ static const char storage_form_c64[] =
   "F,PRG BASIC:,2|prg;"                 // fileselector for PRG
   "F,C64 Kernal:,3|bin;"                // fileselector for Kernal ROM
   "F,TAP Tape:,4|tap;"                  // fileselector for TAP
-  "F,FLT Filter:,5|flt;"                // fileselector for FLT SID Filter
   "L,Disk prot.:,None|8:,P;";           // Enable/Disable Floppy write protection
 
 static const char settings_form_c64[] =
@@ -533,9 +532,7 @@ menu_t *menu_init(u8g2_t *u8g2)
 	  CARD_MOUNTPOINT "/c64crt.crt",
 	  CARD_MOUNTPOINT "/c64prg.prg",
 	  CARD_MOUNTPOINT "/c64kernal.bin",
-	  CARD_MOUNTPOINT "/c64tap.tap",
-  	CARD_MOUNTPOINT "/c64flt.flt"
-    };
+	  CARD_MOUNTPOINT "/c64tap.tap"};
 
 	for(int drive=0;drive<MAX_DRIVES;drive++)
 	  sdc_set_default(drive, c64_default_names[drive]);

--- a/firmware/misterynano_fw/menu.c
+++ b/firmware/misterynano_fw/menu.c
@@ -135,6 +135,7 @@ static const char storage_form_c64[] =
   "F,PRG BASIC:,2|prg;"                 // fileselector for PRG
   "F,C64 Kernal:,3|bin;"                // fileselector for Kernal ROM
   "F,TAP Tape:,4|tap;"                  // fileselector for TAP
+  "F,FLT Filter:,5|flt;"                // fileselector for FLT SID Filter
   "L,Disk prot.:,None|8:,P;";           // Enable/Disable Floppy write protection
 
 static const char settings_form_c64[] =
@@ -532,7 +533,9 @@ menu_t *menu_init(u8g2_t *u8g2)
 	  CARD_MOUNTPOINT "/c64crt.crt",
 	  CARD_MOUNTPOINT "/c64prg.prg",
 	  CARD_MOUNTPOINT "/c64kernal.bin",
-	  CARD_MOUNTPOINT "/c64tap.tap"};
+	  CARD_MOUNTPOINT "/c64tap.tap",
+  	CARD_MOUNTPOINT "/c64flt.flt"
+    };
 
 	for(int drive=0;drive<MAX_DRIVES;drive++)
 	  sdc_set_default(drive, c64_default_names[drive]);

--- a/firmware/misterynano_fw/menu.c
+++ b/firmware/misterynano_fw/menu.c
@@ -135,6 +135,7 @@ static const char storage_form_c64[] =
   "F,PRG BASIC:,2|prg;"                 // fileselector for PRG
   "F,C64 Kernal:,3|bin;"                // fileselector for Kernal ROM
   "F,TAP Tape:,4|tap;"                  // fileselector for TAP
+  "F,FLT Filter:,5|flt;"                // fileselector for FLT SID Filter
   "L,Disk prot.:,None|8:,P;";           // Enable/Disable Floppy write protection
 
 static const char settings_form_c64[] =

--- a/firmware/misterynano_fw/sdc.c
+++ b/firmware/misterynano_fw/sdc.c
@@ -283,7 +283,8 @@ int sdc_handle_event(void) {
   if(request == 4) drive = 2;  // 2 = ACSI 0:
   if(request == 8) drive = 3;  // 3 = ACSI 1:
   if(request == 16) drive = 4; // 4 = Drive C:
-  
+  if(request == 32) drive = 5; // 4 = Drive D:
+
   if(request & 31) {
     if(!fil[drive].flag) {
       // no file selected

--- a/firmware/misterynano_fw/sdc.c
+++ b/firmware/misterynano_fw/sdc.c
@@ -240,7 +240,7 @@ int sdc_is_ready(void) {
 }
 
 static const char *drivename(int drive) {
-  static const char *names[] = { "A", "B", "ACSI 0", "ACSI 1", "C" };
+  static const char *names[] = { "A", "B", "ACSI 0", "ACSI 1", "C", "D" };
   return names[drive];  
 }
 
@@ -283,6 +283,7 @@ int sdc_handle_event(void) {
   if(request == 4) drive = 2;  // 2 = ACSI 0:
   if(request == 8) drive = 3;  // 3 = ACSI 1:
   if(request == 16) drive = 4; // 4 = Drive C:
+  if(request == 32) drive = 5; // 5 = Drive D:
   
   if(request & 31) {
     if(!fil[drive].flag) {

--- a/firmware/misterynano_fw/sdc.c
+++ b/firmware/misterynano_fw/sdc.c
@@ -283,8 +283,7 @@ int sdc_handle_event(void) {
   if(request == 4) drive = 2;  // 2 = ACSI 0:
   if(request == 8) drive = 3;  // 3 = ACSI 1:
   if(request == 16) drive = 4; // 4 = Drive C:
-  if(request == 32) drive = 5; // 4 = Drive D:
-
+  
   if(request & 31) {
     if(!fil[drive].flag) {
       // no file selected

--- a/firmware/misterynano_fw/sdc.h
+++ b/firmware/misterynano_fw/sdc.h
@@ -5,7 +5,7 @@
 
 // up to four image files can be open. E.g. two
 // floppy disks and two ACSI hard drives
-#define MAX_DRIVES  5
+#define MAX_DRIVES  6
 
 // fatfs mounts the card under /sd
 #define CARD_MOUNTPOINT "/sd"

--- a/firmware/misterynano_fw/sdc.h
+++ b/firmware/misterynano_fw/sdc.h
@@ -5,7 +5,7 @@
 
 // up to four image files can be open. E.g. two
 // floppy disks and two ACSI hard drives
-#define MAX_DRIVES  6
+#define MAX_DRIVES  5
 
 // fatfs mounts the card under /sd
 #define CARD_MOUNTPOINT "/sd"


### PR DESCRIPTION
**C64 core** 

- support for one more drive / image to support the loadable SID filter function