### PR TITLE
support onboard BL616 TN20k

### DIFF
--- a/src/tang/nano20k/atarist.cst
+++ b/src/tang/nano20k/atarist.cst
@@ -95,7 +95,9 @@ IO_PORT "spi_sclk" PULL_MODE=UP IO_TYPE=LVCMOS33;
 IO_LOC "spi_dat" 76;
 IO_PORT "spi_dat" PULL_MODE=UP IO_TYPE=LVCMOS33;
 IO_LOC "spi_dir" 75;
-IO_PORT "spi_dir" PULL_MODE=UP IO_TYPE=LVCMOS33;
+IO_PORT "spi_dir" PULL_MODE=NONE DRIVE=8 IO_TYPE=LVCMOS33;
+IO_LOC "spi_irqn" 69; // USB-C UART TX output
+IO_PORT "spi_irqn" PULL_MODE=NONE DRIVE=8 IO_TYPE=LVCMOS33;
 
 // two on-board buttons
 IO_LOC "user" 88;
@@ -108,12 +110,6 @@ IO_LOC "midi_out" 71;
 IO_PORT "midi_out" IO_TYPE=LVCMOS33 DRIVE=8 PULL_MODE=NONE;
 IO_LOC "midi_in" 72;
 IO_PORT "midi_in" IO_TYPE=LVCMOS33 PULL_MODE=DOWN;
-
-// re-used JTAG pins as spi_dat (above) is not really
-// usable as there are resistors and capacistors that
-// limit the max data rate
-// IO_LOC "jtag_tck" 6;
-// IO_PORT "jtag_tck" IO_TYPE=LVCMOS33 PULL_MODE=UP;
 
 IO_LOC "clk" 4;
 IO_PORT "clk" PULL_MODE=UP;

--- a/src/tang/nano20k/atarist_lcd_hdmi.cst
+++ b/src/tang/nano20k/atarist_lcd_hdmi.cst
@@ -74,11 +74,5 @@ IO_PORT "user" IO_TYPE=LVCMOS33 PULL_MODE=UP;
 IO_LOC "reset" 87;
 IO_PORT "reset" IO_TYPE=LVCMOS33 PULL_MODE=UP;
 
-// re-used JTAG pins as spi_dat (above) is not really
-// usable as there are resistors and capacistors that
-// limit the max data rate
-// IO_LOC "jtag_tck" 6;
-// IO_PORT "jtag_tck" IO_TYPE=LVCMOS33 PULL_MODE=UP;
-
 IO_LOC "clk" 4;
 IO_PORT "clk" PULL_MODE=UP;

--- a/src/tang/nano20k/atarist_parport.cst
+++ b/src/tang/nano20k/atarist_parport.cst
@@ -99,19 +99,15 @@ IO_PORT "spi_sclk" PULL_MODE=UP IO_TYPE=LVCMOS33;
 IO_LOC "spi_dat" 76;
 IO_PORT "spi_dat" PULL_MODE=UP IO_TYPE=LVCMOS33;
 IO_LOC "spi_dir" 75;
-IO_PORT "spi_dir" PULL_MODE=UP IO_TYPE=LVCMOS33;
+IO_PORT "spi_dir" PULL_MODE=NONE DRIVE=8 IO_TYPE=LVCMOS33;
+IO_LOC "spi_irqn" 69; // USB-C UART TX output
+IO_PORT "spi_irqn" PULL_MODE=NONE DRIVE=8 IO_TYPE=LVCMOS33;
 
 // two on-board buttons
 IO_LOC "user" 88;
 IO_PORT "user" IO_TYPE=LVCMOS33 PULL_MODE=DOWN;
 IO_LOC "reset" 87;
 IO_PORT "reset" IO_TYPE=LVCMOS33 PULL_MODE=DOWN;
-
-// re-used JTAG pins as spi_dat (above) is not really
-// usable as there are resistors and capacistors that
-// limit the max data rate
-// IO_LOC "jtag_tck" 6;
-// IO_PORT "jtag_tck" IO_TYPE=LVCMOS33 PULL_MODE=UP;
 
 IO_LOC "clk" 4;
 IO_PORT "clk" PULL_MODE=UP;

--- a/src/tang/nano20k/top.sv
+++ b/src/tang/nano20k/top.sv
@@ -51,17 +51,13 @@ module top(
   inout			sd_cmd, // MOSI
   inout [3:0]	sd_dat, // 0: MISO
 	   
-  // SPI connection to ob-board BL616. By default an external
-  // connection is used with a M0S Dock
-  input			spi_sclk, // in... 
-  input			spi_csn, // in (io?)
+  // SPI connection to on-board BL616 for 3921 assemblies 
+  // By default an external connection is used with a M0S Dock
+  input			spi_sclk,// in 
+  input			spi_csn, // in
   output		spi_dir, // out
-  input			spi_dat, // in (io?)
-
-  // spi_dir has a low-pass filter which makes it impossible to use
-  // we thus use jtag_tck as a replacement
-//  output    jtag_tck,
-//  input     jtag_tdi,    // this is being used for interrupt
+  input			spi_dat, // in
+  output		spi_irqn,// out
 
   // hdmi/tdms
   output		tmds_clk_n,
@@ -87,11 +83,10 @@ wire spi_intn;
 
 // intn and dout are outputs driven by the FPGA to the MCU
 // din, ss and clk are inputs coming from the MCU
-
-assign spi_dir = spi_io_dout;   // spi_dir has filter cap and pulldown any basically doesn't work
-// assign jtag_tck = spi_io_dout;
+// onboard connection to on-board BL616 only newer 3921 assemblies 
+assign spi_dir = spi_io_dout;
 assign m0s[5:0] = { 1'bz, spi_intn, 3'bzzz, spi_io_dout };
-// assign jtag_tdi = spi_intn;
+assign spi_irqn = spi_intn;
 
 // by default the internal SPI is being used. Once there is
 // a select from the external spi, then the connection is

--- a/src/tang/nano20k/top_parport.sv
+++ b/src/tang/nano20k/top_parport.sv
@@ -54,17 +54,13 @@ module top(
   inout			sd_cmd, // MOSI
   inout [3:0]	sd_dat, // 0: MISO
 	   
-  // SPI connection to ob-board BL616. By default an external
-  // connection is used with a M0S Dock
-  input			spi_sclk, // in... 
-  input			spi_csn, // in (io?)
+  // SPI connection to on-board BL616 for 3921 assemblies 
+  // By default an external connection is used with a M0S Dock
+  input			spi_sclk,// in 
+  input			spi_csn, // in
   output		spi_dir, // out
-  input			spi_dat, // in (io?)
-
-  // spi_dir has a low-pass filter which makes it impossible to use
-  // we thus use jtag_tck as a replacement
-//  output    jtag_tck,
-//  input     jtag_tdi,    // this is being used for interrupt
+  input			spi_dat, // in
+  output		spi_irqn,// out
 
   // hdmi/tdms
   output		tmds_clk_n,
@@ -90,11 +86,10 @@ wire spi_intn;
 
 // intn and dout are outputs driven by the FPGA to the MCU
 // din, ss and clk are inputs coming from the MCU
-
-assign spi_dir = spi_io_dout;   // spi_dir has filter cap and pulldown any basically doesn't work
-// assign jtag_tck = spi_io_dout;
+// onboard connection to on-board BL616 only newer 3921 assemblies 
+assign spi_dir = spi_io_dout;
 assign m0s[5:0] = { 1'bz, spi_intn, 3'bzzz, spi_io_dout };
-// assign jtag_tdi = spi_intn;
+assign spi_irqn = spi_intn;
 
 // by default the internal SPI is being used. Once there is
 // a select from the external spi, then the connection is


### PR DESCRIPTION
adds support for TN20K onboard BL616 µC: Only newer TN20K assemblies marking: 3921